### PR TITLE
Lua54 fix

### DIFF
--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -33,6 +33,7 @@ paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 smol_str = { version = "0.1.23", features = ["serde"] }
 stacker = { version = "0.1.15", optional = true }
+backtrace = "0.3"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2089,7 +2089,6 @@ define_lua52_parser!(ParseGoto, Goto, TokenReference, |_, state| {
 struct ParseLabel;
 define_lua52_parser!(ParseLabel, Label, TokenReference, |_, state| {
     let (state, left_colons) = ParseSymbol(Symbol::TwoColons).parse(state)?;
-    println!("left_colons: {:?}", left_colons);
     let (state, name) = expect!(
         state,
         ParseIdentifier.parse(state),

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -283,7 +283,7 @@ define_parser!(ParsePartExpression, Expression, |_, state| {
         keep_going!(parse_value(state)).or_else(|_| keep_going!(parse_paren_expression(state)))
     })?;
 
-    #[cfg(feature = "roblox")]
+    #[cfg(not(feature = "roblox"))]
     #[allow(clippy::result_large_err)]
     fn maybe_type_assertion(
         state: ParserState,
@@ -302,7 +302,7 @@ define_parser!(ParsePartExpression, Expression, |_, state| {
         Ok((state, expression))
     }
 
-    #[cfg(not(feature = "roblox"))]
+    #[cfg(feature = "roblox")]
     #[allow(clippy::result_large_err)]
     fn maybe_type_assertion(
         state: ParserState,
@@ -364,11 +364,15 @@ define_roblox_parser!(
     TokenReference,
     |_, state| {
         let (state, assertion_op) = ParseSymbol(Symbol::TwoColons).parse(state)?;
+        println!("in roblox: {:?}", state);
+
         let (state, cast_to) = expect!(
             state,
             ParseTypeInfo(TypeInfoContext::None).parse(state),
             "expected type in type assertion"
         );
+        println!("in roblox: {:?}", state);
+        println!("in roblox: {:?}", cast_to);
 
         Ok((state, TypeAssertion { assertion_op, cast_to }))
     }
@@ -2085,6 +2089,7 @@ define_lua52_parser!(ParseGoto, Goto, TokenReference, |_, state| {
 struct ParseLabel;
 define_lua52_parser!(ParseLabel, Label, TokenReference, |_, state| {
     let (state, left_colons) = ParseSymbol(Symbol::TwoColons).parse(state)?;
+    println!("left_colons: {:?}", left_colons);
     let (state, name) = expect!(
         state,
         ParseIdentifier.parse(state),

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -364,16 +364,11 @@ define_roblox_parser!(
     TokenReference,
     |_, state| {
         let (state, assertion_op) = ParseSymbol(Symbol::TwoColons).parse(state)?;
-        println!("in roblox: {:?}", state);
-
         let (state, cast_to) = expect!(
             state,
             ParseTypeInfo(TypeInfoContext::None).parse(state),
             "expected type in type assertion"
         );
-        println!("in roblox: {:?}", state);
-        println!("in roblox: {:?}", cast_to);
-
         Ok((state, TypeAssertion { assertion_op, cast_to }))
     }
 );


### PR DESCRIPTION

关闭 roblox 的类型推断语法, 避免和 ::lua54_lable:: 撞车